### PR TITLE
Validate UID range when runasnonroot is true

### DIFF
--- a/pkg/kubelet/kuberuntime/security_context_others.go
+++ b/pkg/kubelet/kuberuntime/security_context_others.go
@@ -22,7 +22,8 @@ package kuberuntime
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/securitycontext"
 )
@@ -47,6 +48,8 @@ func verifyRunAsNonRoot(pod *v1.Pod, container *v1.Container, uid *int64, userna
 		return fmt.Errorf("container has runAsNonRoot and image will run as root (pod: %q, container: %s)", format.Pod(pod), container.Name)
 	case uid == nil && len(username) > 0:
 		return fmt.Errorf("container has runAsNonRoot and image has non-numeric user (%s), cannot verify user is non-root (pod: %q, container: %s)", username, format.Pod(pod), container.Name)
+	case uid != nil && validation.IsValidUserID(*uid) != nil:
+		return fmt.Errorf("container has runAsNonRoot and image has an invalid user id (%d): %s (pod: %q, container: %s)", *uid, validation.IsValidUserID(*uid), format.Pod(pod), container.Name)
 	default:
 		return nil
 	}

--- a/pkg/kubelet/kuberuntime/security_context_others_test.go
+++ b/pkg/kubelet/kuberuntime/security_context_others_test.go
@@ -50,6 +50,8 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 
 	rootUser := int64(0)
 	anyUser := int64(1000)
+	invalidUser := int64(2147483648)
+	negativeUser := int64(-1000)
 	runAsNonRootTrue := true
 	runAsNonRootFalse := false
 	for _, test := range []struct {
@@ -137,6 +139,22 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 				RunAsNonRoot: &runAsNonRootTrue,
 			},
 			fail: false,
+		},
+		{
+			desc: "Fail if image's user is invalid and RunAsNonRoot is true",
+			sc: &v1.SecurityContext{
+				RunAsNonRoot: &runAsNonRootTrue,
+			},
+			uid:  &invalidUser,
+			fail: true,
+		},
+		{
+			desc: "Fail if image's user is negative and RunAsNonRoot is true",
+			sc: &v1.SecurityContext{
+				RunAsNonRoot: &runAsNonRootTrue,
+			},
+			uid:  &negativeUser,
+			fail: true,
 		},
 	} {
 		pod.Spec.Containers[0].SecurityContext = test.sc


### PR DESCRIPTION
> Note from Deanna: This PR is a clone of a [PR by `cji`](https://github.com/kubernetes/kubernetes/pull/130871).  The description below is written by him using the project PR template until the "PR Type" section, from then on it is AI written by Qodo Merge until the "Summary by CodeRabbit" section.

#### What type of PR is this?
This is a hardening fix related to [CVE-2024-40635](https://github.com/advisories/GHSA-265r-hfxg-fhmg) in containerd.
 
[GHSA-265r-hfxg-fhmg](https://github.com/containerd/containerd/security/advisories/GHSA-265r-hfxg-fhmg)
 
/kind bug /area security /committee security-response /sig node /area kubelet
 
#### What this PR does / why we need it:
Updating containerd to the versions listed in the advisory will fix this issue.
 
I am introducing this change just as an extra check on valid UID ranges when using `RunAsNonRoot`.
 
#### Which issue(s) this PR fixes:
N/A
 
#### Special notes for your reviewer:
N/A
 
#### Does this PR introduce a user-facing change?
```
NONE
```


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added validation for UID ranges in `verifyRunAsNonRoot`.

- Enhanced error handling for invalid and negative UIDs.

- Introduced new test cases to verify UID validation logic.

- Improved code readability with updated imports and formatting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_context_others.go</strong><dd><code>Add UID validation logic in `verifyRunAsNonRoot`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/kubelet/kuberuntime/security_context_others.go

<li>Added validation for invalid UID ranges in <code>verifyRunAsNonRoot</code>.<br> <li> Enhanced error messages for invalid and negative UIDs.<br> <li> Updated imports for UID validation utility.


</details>


  </td>
  <td><a href="https://github.com/DeannaGelbart/kubernetes-pr-reviewer-experiment/pull/1/files#diff-961319e3d29b8fc5dadfa83fd8da2e10984b23ce7a6b38ee4b295e84ab2ad1ca">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_context_others_test.go</strong><dd><code>Add test cases for UID validation in `verifyRunAsNonRoot`</code></dd></summary>
<hr>

pkg/kubelet/kuberuntime/security_context_others_test.go

<li>Added test cases for invalid and negative UIDs.<br> <li> Verified behavior of <code>verifyRunAsNonRoot</code> with new UID checks.<br> <li> Improved test coverage for UID validation scenarios.


</details>


  </td>
  <td><a href="https://github.com/DeannaGelbart/kubernetes-pr-reviewer-experiment/pull/1/files#diff-e7192232501aa61e3b33aaf4c5ebc591326201275ffd4426eb72a0e7de3622e5">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced non-root container validations by adding stricter checks for valid user IDs, resulting in clearer error feedback when an invalid value is provided.
  
- **Tests**
  - Expanded test coverage to ensure robust verification of non-root container configurations when invalid user IDs are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->